### PR TITLE
interface: Clean-up/rationalize C and C++ interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,10 @@ if(NOT DEFINED NDSU3LIB_MASTER_PROJECT)
   endif()
 endif()
 
-project(ndsu3lib LANGUAGES Fortran CXX)
+project(ndsu3lib LANGUAGES Fortran C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
 
 if(NDSU3LIB_MASTER_PROJECT AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -247,9 +250,14 @@ add_executable(ndsu3lib_example_cpp ndsu3lib_example_cpp.cpp)
 target_link_libraries(ndsu3lib_example_cpp ndsu3lib::ndsu3lib)
 set_target_properties(ndsu3lib_example_cpp PROPERTIES LINKER_LANGUAGE CXX)
 
+add_executable(ndsu3lib_example_c ndsu3lib_example_c.c)
+target_link_libraries(ndsu3lib_example_c ndsu3lib::ndsu3lib)
+set_target_properties(ndsu3lib_example_c PROPERTIES LINKER_LANGUAGE C)
+
 if(NDSU3LIB_MASTER_PROJECT)
   add_custom_target(tests)
   add_dependencies(tests ndsu3lib_example)
   add_dependencies(tests ndsu3lib_example_cpp)
+  add_dependencies(tests ndsu3lib_example_c)
 endif()
 

--- a/ndsu3lib.h
+++ b/ndsu3lib.h
@@ -12,82 +12,40 @@
 #ifndef NDSU3LIB_H_
 #define NDSU3LIB_H_
 
+#include <stdbool.h>
+
+// NDSU3LIB_ALWAYS_INLINE macro for various compilers
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER) || defined(__IBMC__)
+  #define NDSU3LIB_ALWAYS_INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+  #define NDSU3LIB_ALWAYS_INLINE __forceinline
+#elif defined(__NVCC__)
+  #define NDSU3LIB_ALWAYS_INLINE __forceinline__ inline
+#elif defined(_CRAYC)
+  #define NDSU3LIB_ALWAYS_INLINE _Pragma("inline") inline
+#else
+  #define NDSU3LIB_ALWAYS_INLINE inline
+#endif
+
+#ifdef __cplusplus
 namespace ndsu3lib
 {
-   typedef struct {
-      int lambda, mu;
-   } SU3Irrep;
-
    extern "C"
    {
-      namespace fortran
-      {
-	 // for internal use, not intended to be called by the user
+#endif
+   typedef struct {
+      int lambda, mu;
+   } su3irrep;
 
-         extern int outer_multiplicity(SU3Irrep irrep1, SU3Irrep irrep2, SU3Irrep irrep3);
-   
-         extern int inner_multiplicity(SU3Irrep irrep, int L);
-
-         extern void initialize_ndsu3lib(bool wso3, bool openmp, int lmpmu);
-
-         extern void finalize_ndsu3lib(bool wso3);
-
-         extern void calculate_coupling_canonical(
-             const SU3Irrep* irrep1, const SU3Irrep* irrep2, const SU3Irrep* irrep3,
-	     const int* epsilon3, const int* Lambda32, const int* dimpq, const int* dimw, const int* rhomax,
-  	     int* numb, double wigner[], int p1a[], int p2a[], int q2a[]
-           );
-
-         extern void calculate_u_coef(
-             SU3Irrep irrep1, SU3Irrep irrep2, SU3Irrep irrep,
-             SU3Irrep irrep3, SU3Irrep irrep12, SU3Irrep irrep23,
-             int rhomaxa, int rhomaxb, int rhomaxc, int rhomaxd,
-             double* rac, int* info
-           );
-
-         extern void calculate_z_coef(
-             SU3Irrep irrep2, SU3Irrep irrep1, SU3Irrep irrep,
-             SU3Irrep irrep3, SU3Irrep irrep12, SU3Irrep irrep13,
-             int rhomaxa, int rhomaxb, int rhomaxc, int rhomaxd,
-             double* Zcoeff, int* info
-           );
-
-         extern void calculate_9_lambda_mu(
-             SU3Irrep irrep1, SU3Irrep irrep2, SU3Irrep irrep12,
-             SU3Irrep irrep3, SU3Irrep irrep4, SU3Irrep irrep34,
-             SU3Irrep irrep13, SU3Irrep irrep24, SU3Irrep irrep,
-             int rhomax12, int rhomax34, int rhomax1234, int rhomax13, int rhomax24, int rhomax1324,
-             double* ninelm, int* info
-           );
-
-         extern void calculate_coupling_su3so3(
-             SU3Irrep irrep1, int L1, SU3Irrep irrep2, int L2, SU3Irrep irrep3, int L3,
-             int kappa1max, int kappa2max, int kappa3max, int rhomax,
-             double* wigner
-           );
-
-      } // namespace fortran
-   }
-
-   inline
-   int OuterMultiplicity(const SU3Irrep& irrep1, const SU3Irrep& irrep2, const SU3Irrep& irrep3)
-   {
+   extern int outer_multiplicity(su3irrep irrep1, su3irrep irrep2, su3irrep irrep3);
       // Multiplicity of SU(3) coupling (lambda1,mu1)x(lambda2,mu2)->(lambda3,mu3)
       // Input arguments: irrep1,irrep2,irrep3
-      return fortran::outer_multiplicity(irrep1, irrep2, irrep3);
-   }
 
-   inline
-   int InnerMultiplicity(const SU3Irrep& irrep, const int& L)
-   {
+   extern int inner_multiplicity(su3irrep irrep, int L);
       // Inner multiplicity of L within SU(3) irrep (lambda,mu)
       // Input arguments: irrep,L
-      return fortran::inner_multiplicity(irrep, L);
-   }
 
-   inline
-   void InitializeNdsu3lib(const bool& wso3, const bool& openmp, const int& lmpmu)
-   {
+   extern void initialize_ndsu3lib(bool wso3, bool openmp, int lmpmu);
       // ndsu3lib initialization subroutine
       // Must be called by the main program before calling
       // ndsu3lib subroutines for SU(3) coupling or recoupling coefficients.
@@ -99,29 +57,21 @@ namespace ndsu3lib
       // calculated.
       // openmp must be .TRUE. if OpenMP is used, otherwise it must be .FALSE.
       // lmpmu should be greater than or equal to the maximal expected value of lambda+mu.
-      fortran::initialize_ndsu3lib(wso3, openmp, lmpmu);
-   }
 
-   inline
-   void FinalizeNdsu3lib(const bool& wso3)
-   {
+   extern void finalize_ndsu3lib(bool wso3);
       // This subroutine should be called by each thread once SU(3) coupling or
       // recoupling coefficients are not going to be calculated anymore to free memory.
       //
       // Input argument: wso3
-      // 
+      //
       // wso3 should be true if initialize_ndsu3lib or initialize_ndsu3lib_thread
       // was called with the first argument being true.
-      fortran::finalize_ndsu3lib(wso3);
-   }
 
-   inline
-   void CalculateCouplingCanonical(
-       const SU3Irrep& irrep1, const SU3Irrep& irrep2, const SU3Irrep& irrep3,
-       const int& epsilon3, const int& Lambda32, const int& dimpq, const int& dimw, const int& rhomax,
-       int& numb, double wigner[], int p1a[], int p2a[], int q2a[]
-     )
-   {
+   extern void calculate_coupling_canonical(
+         su3irrep irrep1, su3irrep irrep2, su3irrep irrep3,
+         int epsilon3, int Lambda32, int dimpq, int dimw, int rhomax,
+         int* numb, double wigner[], int p1a[], int p2a[], int q2a[]
+      );
       // Calculate SU(3)-SU(2)xU(1) reduced coupling coefficients
       // / (lambda1,mu1)    (lambda2,mu2)   ||  (lambda3,mu3)  \
       // \epsilon1,Lambda1 epsilon2,Lambda2 || epsilon3,Lambda3/rho
@@ -145,26 +95,18 @@ namespace ndsu3lib
       //   epsilon1=epsilon3-epsilon2
       //   Lambda1=(mu1+p1-q1)/2
       //   Lambda2=(mu2+p2-q2)/2
-      fortran::calculate_coupling_canonical(
-          &irrep1, &irrep2, &irrep3,
-          &epsilon3, &Lambda32, &dimpq, &dimw, &rhomax,
-          &numb, wigner, p1a, p2a, q2a
-        );
-   }
 
-   inline
-   int CalculateUCoef(
-       const SU3Irrep& irrep1, const SU3Irrep& irrep2, const SU3Irrep& irrep,
-       const SU3Irrep& irrep3, const SU3Irrep& irrep12, const SU3Irrep& irrep23,
-       const int& rhomaxa, const int& rhomaxb, const int& rhomaxc, const int& rhomaxd,
-       double* rac
-     )
-   {
+   extern int calculate_u_coef(
+         su3irrep irrep1, su3irrep irrep2, su3irrep irrep,
+         su3irrep irrep3, su3irrep irrep12, su3irrep irrep23,
+         int rhomaxa, int rhomaxb, int rhomaxc, int rhomaxd,
+         double rac[]
+      );
       // Calculate SU(3) recoupling U coefficients
       // U[(lambda1,mu1)(lambda2,mu2)(lambda,mu)(lambda3,mu3)rhoa,rhob(lambda12,mu12)(lambda23,mu23)rhoc,rhod]
       // for given lambda1,mu1,lambda2,mu2,lambda,mu,lambda3,mu3,lambda12,mu12,lambda23,mu23
       // calling Lapack subroutine dgesv to solve system of linear equations
-      // Returns is 0 iff Lapack subroutine dgesv ran withou errors.
+      // Returns is 0 iff Lapack subroutine dgesv ran without errors.
       //
       // Input arguments: irrep1,irrep2,irrep,irrep3,irrep12,irrep23,rhomaxa,rhomaxb,rhomaxc,rhomaxd
       // Output argument: rac
@@ -175,29 +117,18 @@ namespace ndsu3lib
       // rhomaxd is multiplicity of SU(3) coupling (lambda1,mu1)x(lambda23,mu23)->(lambda,mu),
       // rac(ind), where ind=rhod-1+rhomaxd*(rhoa-1)+rhomaxd*rhomaxa*(rhob-1)+rhomaxd*rhomaxa*rhomaxb*(rhoc-1)
       //   is U coefficient for given rhoa,rhob,rhoc,rhod,
-      int info;
-      fortran::calculate_u_coef(
-          irrep1, irrep2, irrep,
-          irrep3, irrep12, irrep23,
-          rhomaxa, rhomaxb, rhomaxc, rhomaxd,
-          rac, &info
-        );
-      return info;
-   }
 
-   inline
-   int CalculateZCoef(
-       const SU3Irrep& irrep2, const SU3Irrep& irrep1, const SU3Irrep& irrep,
-       const SU3Irrep& irrep3, const SU3Irrep& irrep12, const SU3Irrep& irrep13,
-       const int& rhomaxa, const int& rhomaxb, const int& rhomaxc, const int& rhomaxd,
-       double* Zcoeff
-     )
-   {
+   extern int calculate_z_coef(
+         su3irrep irrep2, su3irrep irrep1, su3irrep irrep,
+         su3irrep irrep3, su3irrep irrep12, su3irrep irrep13,
+         int rhomaxa, int rhomaxb, int rhomaxc, int rhomaxd,
+         double Zcoeff[]
+      );
       // Calculate SU(3) recoupling Z coefficients
       // Z[(lambda2,mu2)(lambda1,mu1)(lambda,mu)(lambda3,mu3)rhoa,rhob(lambda12,mu12)(lambda13,mu13)rhoc,rhod]
       // for given lambda2,mu2,lambda1,mu1,lambda,mu,lambda3,mu3,lambda12,mu12,lambda13,mu13
       // calling Lapack subroutine dgesv to solve system of linear equations
-      // Returns is 0 iff Lapack subroutine dgesv ran withou errors.
+      // Returns is 0 iff Lapack subroutine dgesv ran without errors.
       //
       // Input arguments: irrep2,irrep1,irrep,irrep3,irrep12,irrep13,rhomaxa,rhomaxb,rhomaxc,rhomaxd
       // Output argument: Zcoeff
@@ -208,26 +139,14 @@ namespace ndsu3lib
       // rhomaxd is multiplicity of SU(3) coupling (lambda13,mu13)x(lambda2,mu2)->(lambda,mu),
       // Zcoeff(ind), where ind=rhod-1+rhomaxd*(rhoa-1)+rhomaxd*rhomaxa*(rhob-1)+rhomaxd*rhomaxa*rhomaxb*(rhoc-1)
       //   is Z coefficient for given rhoa,rhob,rhoc,rhod,
-      int info;
-      fortran::calculate_z_coef(
-          irrep2, irrep1, irrep,
-          irrep3, irrep12, irrep13,
-          rhomaxa, rhomaxb, rhomaxc, rhomaxd,
-          Zcoeff, &info
-        );
-      return info;
-   }
 
-   inline
-   int Calculate9LambdaMu(
-       const SU3Irrep& irrep1, const SU3Irrep& irrep2, const SU3Irrep& irrep12,
-       const SU3Irrep& irrep3, const SU3Irrep& irrep4, const SU3Irrep& irrep34,
-       const SU3Irrep& irrep13, const SU3Irrep& irrep24, const SU3Irrep& irrep,
-       const int& rhomax12, const int& rhomax34, const int& rhomax1234,
-       const int& rhomax13, const int& rhomax24, const int& rhomax1324,
-       double* ninelm
-     )
-   {
+   extern int calculate_9_lambda_mu(
+         su3irrep irrep1, su3irrep irrep2, su3irrep irrep12,
+         su3irrep irrep3, su3irrep irrep4, su3irrep irrep34,
+         su3irrep irrep13, su3irrep irrep24, su3irrep irrep,
+         int rhomax12, int rhomax34, int rhomax1234, int rhomax13, int rhomax24, int rhomax1324,
+         double ninelm[]
+      );
       // Calculate 9-(lambda,mu) coefficients
       //
       // | (lambda1,mu1)   (lambda2,mu2)  (lambda12,mu12)  rho12 |
@@ -238,7 +157,7 @@ namespace ndsu3lib
       // for given lambda1,mu1,lambda2,mu2,lambda12,mu12,lambda3,mu3,lambda4,mu4,
       // lambda34,mu34,lambda13,mu13,lambda24,mu24,lambda,mu
       // from U and Z coefficients obtained by calling calculate_u_coef and calculate_z_coef
-      // Returns is 0 iff Lapack subroutine dgesv ran withou errors.
+      // Returns is 0 iff Lapack subroutine dgesv ran without errors.
       //
       // Input arguments: irrep1,irrep2,irrep12,irrep3,irrep4,irrep34,irrep13,irrep24,irrep,
       //                  rhomax12,rhomax34,rhomax1234,rhomax13,rhomax24,rhomax1324
@@ -253,27 +172,12 @@ namespace ndsu3lib
       // ninelm(ind), where ind=rho12+rhomax12*(rho34-1)+rhomax12*rhomax34*(rho1234-1)+rhomax12*rhomax34*rhomax1234*(rho13-1)
       //   +rhomax12*rhomax34*rhomax1234*rhomax13*(rho24-1)+rhomax12*rhomax34*rhomax1234*rhomax13*rhomax24*(rho1324-1)-1,
       //   is 9-(lambda,mu) coefficient for given rho12,rho34,rho1234,rho13,rho24,rho1324,
-      int info;
-      fortran::calculate_9_lambda_mu(
-          irrep1, irrep2, irrep12,
-          irrep3, irrep4, irrep34,
-          irrep13, irrep24, irrep,
-          rhomax12, rhomax34, rhomax1234,
-          rhomax13, rhomax24, rhomax1324,
-          ninelm, &info
-        );
-      return info;
-   }
 
-   inline
-   void CalculateCouplingSU3SO3(
-       const SU3Irrep& irrep1, const int& L1,
-       const SU3Irrep& irrep2, const int& L2,
-       const SU3Irrep& irrep3, const int& L3,
-       const int& kappa1max, const int& kappa2max, const int& kappa3max, const int& rhomax,
-       double* wigner
-     )
-   {
+   extern void calculate_coupling_su3so3(
+         su3irrep irrep1, int L1, su3irrep irrep2, int L2, su3irrep irrep3, int L3,
+         int kappa1max, int kappa2max, int kappa3max, int rhomax,
+         double wigner[]
+      );
       // Calculate SU(3)-SO(3) reduced coupling coefficients
       // /(lambda1,mu1) (lambda2,mu2) || (lambda3,mu3)\
       // \  kappa1,L1     kappa2,L2   ||   kappa3,L3  /rho
@@ -289,13 +193,27 @@ namespace ndsu3lib
       // wigner(ind), where
       //   ind=kappa1-1+kappa1max*(kappa2-1)+kappa1max*kappa2max*(kappa3-1)+kappa1max*kappa2max*kappa3max*(rho-1),
       //   is reduced coupling coefficient for given kappa1,kappa2,kappa3,rho.
-      fortran::calculate_coupling_su3so3(
-          irrep1, L1, irrep2, L2, irrep3, L3,
-          kappa1max, kappa2max, kappa3max, rhomax,
-          wigner
-        );
+
+#ifdef __cplusplus
+}  // extern "C"
+
+   // C++ pass-by-reference wrappers
+
+   NDSU3LIB_ALWAYS_INLINE
+   void calculate_coupling_canonical(
+         const su3irrep& irrep1, const su3irrep& irrep2, const su3irrep& irrep3,
+         const int& epsilon3, const int& Lambda32, const int& dimpq, const int& dimw, const int& rhomax,
+         int& numb, double wigner[], int p1a[], int p2a[], int q2a[]
+      )
+   {
+      calculate_coupling_canonical(
+            irrep1, irrep2, irrep3,
+            epsilon3, Lambda32, dimpq, dimw, rhomax,
+            &numb, wigner, p1a, p2a, q2a
+         );
    }
 
 }  // namespace ndsu3lib
+#endif  // __cplusplus
 
 #endif  // NDSU3LIB_H_

--- a/ndsu3lib_coupling_canonical.F90
+++ b/ndsu3lib_coupling_canonical.F90
@@ -480,7 +480,7 @@ CONTAINS
       ! Setting the phase according to Eq.(48) in [1]
       !**********************************************
       phiprhomax = lambda1 + lambda2 - lambda3 + mu1 + mu2 - mu3 + rhomax ! phiprhomax is phi+rhomax
-      i4 = phiprhomax + (lambda1 + Lambda22max - lambda3)/2 
+      i4 = phiprhomax + (lambda1 + Lambda22max - lambda3)/2
       ! i4 is lambda1+lambda2-lambda3+mu1+mu2-mu3+rhomax+(lambda1+2*Lambda2_max-lambda3)/2
       p2 = (noname1 - mu2 + Lambda22max)/2
       q2 = noname1 - p2
@@ -968,21 +968,21 @@ CONTAINS
       !--------------------------------------------------------------------------------------------------------
       !USE ISO_C_BINDING
       IMPLICIT NONE
-      TYPE(su3irrep), INTENT(IN) :: irrep1
+      TYPE(su3irrep), INTENT(IN), VALUE :: irrep1
          !! First SU(3) irrep in SU(3) coupling, i.e., (lambda1,mu1)
-      TYPE(su3irrep), INTENT(IN) :: irrep2
+      TYPE(su3irrep), INTENT(IN), VALUE :: irrep2
          !! Second SU(3) irrep in SU(3) coupling, i.e., (lambda2,mu2)
-      TYPE(su3irrep), INTENT(IN) :: irrep3
+      TYPE(su3irrep), INTENT(IN), VALUE :: irrep3
          !! Resulting SU(3) irrep, i.e., (lambda3,mu3)
-      INTEGER(C_INT), INTENT(IN) :: epsilon3
+      INTEGER(C_INT), INTENT(IN), VALUE :: epsilon3
          !! epsilon3
-      INTEGER(C_INT), INTENT(IN) :: Lambda32
+      INTEGER(C_INT), INTENT(IN), VALUE :: Lambda32
          !! 2*Lambda3
-      INTEGER(C_INT), INTENT(IN) :: dimpq
+      INTEGER(C_INT), INTENT(IN), VALUE :: dimpq
          !! Size of arrays p1a,p2a,q2a, which should be at least (MAX(lambda1,mu1)+1)*(lambda2+1)*(mu2+1)
-      INTEGER(C_INT), INTENT(IN) :: dimw
+      INTEGER(C_INT), INTENT(IN), VALUE :: dimw
          !! Size of array wigner_block, which should be at least rhomax*dimpq
-      INTEGER(C_INT), INTENT(IN) :: rhomax
+      INTEGER(C_INT), INTENT(IN), VALUE :: rhomax
          !! Multiplicity of SU(3) coupling
       INTEGER(C_INT), INTENT(OUT) :: numb
          !! Number of resulting reduced coupling coefficients for given outer multiplicity index

--- a/ndsu3lib_example_c.c
+++ b/ndsu3lib_example_c.c
@@ -1,0 +1,263 @@
+/********************************************************************************************************************
+
+ ndsu3lib_example_cpp.cpp
+//! Simple program tabulating SU(3) reduced coupling and recoupling coefficients to demonstrate usage of C wrappers
+
+ Jakub Herko
+ University of Notre Dame
+ Patrick J. Fasano
+ University of Notre Dame, Argonne National Laboratory
+
+ SPDX-License-Identifier: MIT
+
+********************************************************************************************************************/
+#include <stdio.h>
+
+#include "ndsu3lib.h"
+
+#define max(a,b)      (((a) > (b)) ? (a) : (b))
+
+void tabulate_coupling_canonical()
+   // Tabulate SU(3)-SU(2)xU(1) reduced coupling coefficients
+   // /     (6,1)            (2,1)       ||  (5,2) \
+   // \epsilon1,Lambda1 epsilon2,Lambda2 || -9,5/2 /rho
+   {
+      su3irrep irrep1 = {6,1}, irrep2 = {2,1}, irrep3 = {5,2};
+      int epsilon3 = -9,
+          Lambda3_twice = 5, // Lambda3_twice is 2*Lambda3
+          rhomax = outer_multiplicity(irrep1, irrep2, irrep3),
+          dimpq = (max(irrep1.lambda,irrep1.mu) + 1)*(irrep2.lambda + 1)*(irrep2.mu + 1);
+      int dimw = rhomax*dimpq,
+          numb;
+      int p1a[dimpq], p2a[dimpq], q2a[dimpq];
+      double coupling[dimw];
+      calculate_coupling_canonical(
+          irrep1, irrep2, irrep3, epsilon3, Lambda3_twice,
+          dimpq, dimw, rhomax, &numb, coupling, p1a, p2a, q2a
+        );
+      printf("SU(3)-SU(2)xU(1) reduced coupling coefficients\n");
+      printf("/     (6,1)            (2,1)       ||  (5,2) \\\n");
+      printf("\\epsilon1,Lambda1 epsilon2,Lambda2 || -9,5/2 /rho\n");
+      printf("epsilon1  2*Lambda1  epsilon2  2*Lambda2  coefficients for rho=1,...,rhomax=%d\n",rhomax);
+      for (int i = 0; i < numb; i++)
+      {
+         int p1 = p1a[i],
+            p2 = p2a[i],
+            q2 = q2a[i];
+         int q1 = (2*(irrep1.lambda + irrep2.lambda) + irrep1.mu + irrep2.mu - epsilon3)/3 - p1 - p2 - q2,
+            epsilon2 = 2*irrep2.lambda + irrep2.mu - 3*(p2 + q2);
+         int epsilon1 = epsilon3 - epsilon2,
+            Lambda1_twice = irrep1.mu + p1 - q1, // Lambda1_twice is 2*Lambda1
+            Lambda2_twice = irrep2.mu + p2 - q2; // Lambda2_twice is 2*Lambda2
+         printf(
+            "   %d         %d         %d         %d      ",
+            epsilon1, Lambda1_twice, epsilon2, Lambda2_twice
+            );
+         for (int rho = 1; rho <= rhomax; rho++)
+         {
+            int ind = i + numb*(rho - 1);
+            printf("%f  ", coupling[ind]);
+         }
+         printf("\n");
+      }
+   }
+
+void tabulate_coupling_su3so3()
+   // Tabulate SU(3)-SO(3) reduced coupling coefficients
+   // / (6,1)    (2,1)   ||  (5,2)  \
+   // \kappa1,2 kappa2,3 || kappa3,3/rho
+   {
+      su3irrep irrep1 = {6,1}, irrep2 = {2,1}, irrep3 = {5,2};
+      int L1 = 2, L2 = 3, L3 = 3;
+      int rhomax = outer_multiplicity(irrep1, irrep2, irrep3),
+          kappa1max = inner_multiplicity(irrep1, L1),
+          kappa2max = inner_multiplicity(irrep2, L2),
+          kappa3max = inner_multiplicity(irrep3, L3);
+      int dimen = kappa1max*kappa2max*kappa3max*rhomax;
+      double coupling[dimen];
+      calculate_coupling_su3so3(
+         irrep1, L1, irrep2, L2, irrep3, L3, kappa1max, kappa2max, kappa3max,
+         rhomax, coupling
+         );
+      printf("\n");
+      printf("SU(3)-SO(3) reduced coupling coefficients\n");
+      printf("/ (6,1)    (2,1)   ||  (5,2)  \\\n");
+      printf("\\kappa1,2 kappa2,3 || kappa3,3/rho\n");
+      printf("kappa1  kappa2  kappa3  coefficients for rho=1,...,rhomax=%d\n", rhomax);
+      for (int kappa1 = 1; kappa1 <= kappa1max; kappa1++)
+      {
+         for (int kappa2 = 1; kappa2 <= kappa2max; kappa2++)
+         {
+            for (int kappa3 = 1; kappa3 <= kappa3max; kappa3++)
+            {
+               printf("   %d       %d       %d    ", kappa1, kappa2, kappa3);
+               for (int rho = 1; rho <= rhomax; rho++)
+               {
+                  int ind = kappa1 + kappa1max*(kappa2 - 1)
+                            + kappa1max*kappa2max*(kappa3 - 1)
+                            + kappa1max*kappa2max*kappa3max*(rho - 1) - 1;
+                  printf("%f  ", coupling[ind]);
+               }
+               printf("\n");
+            }
+         }
+      }
+   }
+
+void tabulate_u_coef()
+   // Tabulate SU(3) recoupling U coefficients
+   // U[(9,3)(1,1)(6,6)(2,2);(9,3)rhoa,rhob(3,3)rhoc,rhod]
+   {
+      su3irrep irrep1 = {9,3}, irrep2 = {1,1}, irrep = {6,6},
+               irrep3 = {2,2}, irrep12 = {9,3}, irrep23 = {3,3};
+      int rhomaxa = outer_multiplicity(irrep1, irrep2, irrep12),
+          rhomaxb = outer_multiplicity(irrep12, irrep3, irrep),
+          rhomaxc = outer_multiplicity(irrep2, irrep3, irrep23),
+          rhomaxd = outer_multiplicity(irrep1, irrep23, irrep);
+      int dimen = rhomaxa*rhomaxb*rhomaxc*rhomaxd;
+      double rac[dimen];
+      int info = calculate_u_coef(
+         irrep1, irrep2, irrep, irrep3, irrep12, irrep23,
+         rhomaxa, rhomaxb, rhomaxc, rhomaxd,
+         rac
+         );
+      printf("\n");
+      if (info != 0)
+      {
+         printf("calculate_u_coef: Lapack subroutine dgesv ran with error: info=%d\n", info);
+         return;
+      }
+      printf("SU(3) recoupling coefficients U[(9,3)(1,1)(6,6)(2,2);(9,3)rhoa,rhob(3,3)rhoc,rhod]\n");
+      printf("rhoa  rhob  rhoc  rhod  coefficient\n");
+      for (int rhoa = 1; rhoa <= rhomaxa; rhoa++)
+      {
+         for (int rhob = 1; rhob <= rhomaxb; rhob++)
+         {
+            for (int rhoc = 1; rhoc <= rhomaxc; rhoc++)
+            {
+               for (int rhod = 1; rhod <= rhomaxd; rhod++)
+               {
+                  int ind = rhod - 1 + rhomaxd*(rhoa - 1) + rhomaxd*rhomaxa*(rhob - 1) + rhomaxd*rhomaxa*rhomaxb*(rhoc - 1);
+                  printf("  %d     %d     %d     %d   %f\n", rhoa, rhob, rhoc, rhod, rac[ind]);
+               }
+            }
+         }
+      }
+   }
+
+void tabulate_z_coef()
+   // Tabulate SU(3) recoupling Z coefficients
+   // Z[(9,3)(1,1)(6,6)(2,2);(9,3)rhoa,rhob(3,3)rhoc,rhod]
+   {
+      su3irrep irrep2 = {9, 3}, irrep1 = {1, 1}, irrep = {6, 6},
+               irrep3 = {2, 2}, irrep12 = {9, 3}, irrep13 = {3, 3};
+      int rhomaxa = outer_multiplicity(irrep1, irrep2, irrep12),
+          rhomaxb = outer_multiplicity(irrep12, irrep3, irrep),
+          rhomaxc = outer_multiplicity(irrep1, irrep3, irrep13),
+          rhomaxd = outer_multiplicity(irrep13, irrep2, irrep);
+      int dimen = rhomaxa*rhomaxb*rhomaxc*rhomaxd;
+      double Zcoeff[dimen];
+      int info = calculate_z_coef(
+         irrep2, irrep1, irrep, irrep3, irrep12, irrep13,
+         rhomaxa, rhomaxb, rhomaxc, rhomaxd,
+         Zcoeff
+      );
+      printf("\n");
+      if (info != 0)
+      {
+         printf("calculate_z_coef: Lapack subroutine dgesv ran with error: info=%d\n", info);
+         return;
+      }
+      printf("SU(3) recoupling coefficients Z[(9,3)(1,1)(6,6)(2,2);(9,3)rhoa,rhob(3,3)rhoc,rhod]\n");
+      printf("rhoa  rhob  rhoc  rhod  coefficient\n");
+      for (int rhoa = 1; rhoa <= rhomaxa; rhoa++)
+      {
+         for (int rhob = 1; rhob <= rhomaxb; rhob++)
+         {
+            for (int rhoc = 1; rhoc <= rhomaxc; rhoc++)
+            {
+               for (int rhod = 1; rhod <= rhomaxd; rhod++)
+               {
+                  int ind = rhod - 1 + rhomaxd*(rhoa - 1) + rhomaxd*rhomaxa*(rhob - 1) + rhomaxd*rhomaxa*rhomaxb*(rhoc - 1);
+                  printf("  %d     %d     %d     %d   %f\n", rhoa, rhob, rhoc, rhod, Zcoeff[ind]);
+               }
+            }
+         }
+      }
+   }
+
+void tabulate_nine_lm()
+   // Tabulate 9-(lambda,mu) coefficients
+   // |(1,1) (0,0)  (1,1)  rho12 |
+   // |(0,4) (4,2)  (2,4)  rho34 |
+   // |(2,3) (4,2)  (2,4) rho1324|
+   // |rho13 rho24 rho1234       |
+   {
+      su3irrep irrep1 = {1, 1}, irrep2 = {0, 0}, irrep12 = {1, 1},
+               irrep3 = {0, 4}, irrep4 = {4, 2}, irrep34 = {2, 4},
+               irrep13 = {2, 3}, irrep24 = {4, 2}, irrep = {2, 4};
+      int rhomax12 = outer_multiplicity(irrep1, irrep2, irrep12),
+          rhomax34 = outer_multiplicity(irrep3, irrep4, irrep34),
+          rhomax1234 = outer_multiplicity(irrep12, irrep34, irrep),
+          rhomax13 = outer_multiplicity(irrep1, irrep3, irrep13),
+          rhomax24 = outer_multiplicity(irrep2, irrep4, irrep24),
+          rhomax1324 = outer_multiplicity(irrep13, irrep24, irrep);
+      int dimen = rhomax12*rhomax34*rhomax1234*rhomax13*rhomax24*rhomax1324;
+      double ninelm[dimen];
+      int info = calculate_9_lambda_mu(
+         irrep1, irrep2, irrep12,
+         irrep3, irrep4, irrep34,
+         irrep13, irrep24, irrep,
+         rhomax12, rhomax34, rhomax1234, rhomax13, rhomax24, rhomax1324,
+         ninelm
+      );
+      printf("\n");
+      if(info != 0)
+      {
+         printf("calculate_9_lambda_mu: Lapack subroutine dgesv ran with error: info=%d\n", info);
+         return;
+      }
+      printf("                           |(1,1) (0,0)  (1,1)  rho12 |\n");
+      printf("9-(lambda,mu) coefficients |(0,4) (4,2)  (2,4)  rho34 |\n");
+      printf("                           |(2,3) (4,2)  (2,4) rho1324|\n");
+      printf("                           |rho13 rho24 rho1234       |\n");
+      printf("rho12  rho34  rho1234  rho13  rho24  rho1324  coefficient\n");
+      for (int rho12 = 1; rho12 <= rhomax12; rho12++)
+      {
+         for (int rho34 = 1; rho34 <= rhomax34; rho34++)
+         {
+            for (int rho1234 = 1; rho1234 <= rhomax1234; rho1234++)
+            {
+               for (int rho13 = 1; rho13 <= rhomax13; rho13++)
+               {
+                  for (int rho24 = 1; rho24 <= rhomax24; rho24++)
+                  {
+                     for (int rho1324 = 1; rho1324 <= rhomax1324; rho1324++)
+                     {
+                        int ind = rho12 - 1 + rhomax12*(rho34 - 1) + rhomax12*rhomax34*(rho1234 - 1)
+                                  + rhomax12*rhomax34*rhomax1234*(rho13 - 1)
+                                  + rhomax12*rhomax34*rhomax1234*rhomax13*(rho24 - 1)
+                                  + rhomax12*rhomax34*rhomax1234*rhomax13*rhomax24*(rho1324 - 1);
+                        printf(
+                           "  %d      %d       %d       %d      %d       %d     %f\n",
+                           rho12, rho34, rho1234, rho13, rho24, rho1324, ninelm[ind]
+                        );
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+
+int main()
+{
+   initialize_ndsu3lib(true, false, 50);
+   tabulate_coupling_canonical();
+   tabulate_coupling_su3so3();
+   tabulate_u_coef();
+   tabulate_z_coef();
+   tabulate_nine_lm();
+   finalize_ndsu3lib(true);
+   return 0;
+}

--- a/ndsu3lib_example_cpp.cpp
+++ b/ndsu3lib_example_cpp.cpp
@@ -18,24 +18,24 @@ void tabulate_coupling_canonical()
    // /     (6,1)            (2,1)       ||  (5,2) \
    // \epsilon1,Lambda1 epsilon2,Lambda2 || -9,5/2 /rho
    {
-      ndsu3lib::SU3Irrep irrep1 = {6, 1}, irrep2 = {2, 1}, irrep3 = {5, 2};
+      ndsu3lib::su3irrep irrep1 = {6, 1}, irrep2 = {2, 1}, irrep3 = {5, 2};
       int epsilon3 = -9,
           Lambda3_twice = 5, // Lambda3_twice is 2*Lambda3
-          rhomax = ndsu3lib::OuterMultiplicity(irrep1, irrep2, irrep3),
+          rhomax = ndsu3lib::outer_multiplicity(irrep1, irrep2, irrep3),
           dimpq = (std::max(irrep1.lambda, irrep1.mu) + 1)*(irrep2.lambda + 1)*(irrep2.mu + 1);
       int dimw = rhomax*dimpq,
           numb;
       int p1a[dimpq], p2a[dimpq], q2a[dimpq];
-      double wigner[dimw];
-      ndsu3lib::CalculateCouplingCanonical(
-          irrep1, irrep2, irrep3, epsilon3, Lambda3_twice, dimpq, dimw, rhomax,
-	  numb, wigner, p1a, p2a, q2a
+      double coupling[dimw];
+      ndsu3lib::calculate_coupling_canonical(
+          irrep1, irrep2, irrep3, epsilon3, Lambda3_twice,
+          dimpq, dimw, rhomax, numb, coupling, p1a, p2a, q2a
         );
       std::cout << "SU(3)-SU(2)xU(1) reduced coupling coefficients" << std::endl;
       std::cout << "/     (6,1)            (2,1)       ||  (5,2) \\" << std::endl;
       std::cout << "\\epsilon1,Lambda1 epsilon2,Lambda2 || -9,5/2 /rho" << std::endl;
       std::cout << "epsilon1  2*Lambda1  epsilon2  2*Lambda2  coefficients for rho=1,...,rhomax=" << rhomax << std::endl;
-      for (int i = 0; i <= numb - 1; i++)
+      for (int i = 0; i < numb; i++)
       {
          int p1 = p1a[i],
              p2 = p2a[i],
@@ -50,7 +50,7 @@ void tabulate_coupling_canonical()
          for (int rho = 1; rho <= rhomax; rho++)
          {
             int ind = i + numb*(rho - 1);
-            std::cout << wigner[ind] << "  ";
+            std::cout << coupling[ind] << "  ";
          }
          std::cout << std::endl;
       }
@@ -61,18 +61,18 @@ void tabulate_coupling_su3so3()
    // / (6,1)    (2,1)   ||  (5,2)  \
    // \kappa1,2 kappa2,3 || kappa3,3/rho
    {
-      ndsu3lib::SU3Irrep irrep1 = {6, 1}, irrep2 = {2, 1}, irrep3 = {5, 2};
+      ndsu3lib::su3irrep irrep1 = {6, 1}, irrep2 = {2, 1}, irrep3 = {5, 2};
       int L1 = 2, L2 = 3, L3 = 3;
-      int rhomax = ndsu3lib::OuterMultiplicity(irrep1, irrep2, irrep3),
-          kappa1max = ndsu3lib::InnerMultiplicity(irrep1, L1),
-          kappa2max = ndsu3lib::InnerMultiplicity(irrep2, L2),
-          kappa3max = ndsu3lib::InnerMultiplicity(irrep3, L3);
+      int rhomax = ndsu3lib::outer_multiplicity(irrep1, irrep2, irrep3),
+          kappa1max = ndsu3lib::inner_multiplicity(irrep1, L1),
+          kappa2max = ndsu3lib::inner_multiplicity(irrep2, L2),
+          kappa3max = ndsu3lib::inner_multiplicity(irrep3, L3);
       int dimen = kappa1max*kappa2max*kappa3max*rhomax;
-      double wigner[dimen];
-      ndsu3lib::CalculateCouplingSU3SO3(
-          irrep1, L1, irrep2, L2, irrep3, L3, kappa1max, kappa2max, kappa3max, rhomax,
-	  wigner
-        );
+      double coupling[dimen];
+      ndsu3lib::calculate_coupling_su3so3(
+         irrep1, L1, irrep2, L2, irrep3, L3, kappa1max, kappa2max, kappa3max,
+         rhomax, coupling
+         );
       std::cout << std::endl;
       std::cout << "SU(3)-SO(3) reduced coupling coefficients" << std::endl;
       std::cout << "/ (6,1)    (2,1)   ||  (5,2)  \\" << std::endl;
@@ -87,9 +87,10 @@ void tabulate_coupling_su3so3()
                std::cout << "   " << kappa1 << "       " << kappa2 << "       " << kappa3 << "    ";
                for (int rho = 1; rho <= rhomax; rho++)
                {
-                  int ind = kappa1 + kappa1max*(kappa2 - 1) + kappa1max*kappa2max*(kappa3 - 1)
+                  int ind = kappa1 + kappa1max*(kappa2 - 1)
+                            + kappa1max*kappa2max*(kappa3 - 1)
                             + kappa1max*kappa2max*kappa3max*(rho - 1) - 1;
-                  std::cout << wigner[ind] << "  ";
+                  std::cout << coupling[ind] << "  ";
                }
                std::cout << std::endl;
             }
@@ -101,22 +102,23 @@ void tabulate_u_coef()
    // Tabulate SU(3) recoupling U coefficients
    // U[(9,3)(1,1)(6,6)(2,2);(9,3)rhoa,rhob(3,3)rhoc,rhod]
    {
-      ndsu3lib::SU3Irrep irrep1 = {9, 3}, irrep2 = {1, 1}, irrep = {6, 6},
+      ndsu3lib::su3irrep irrep1 = {9, 3}, irrep2 = {1, 1}, irrep = {6, 6},
                          irrep3 = {2, 2}, irrep12 = {9, 3}, irrep23 = {3, 3};
-      int rhomaxa = ndsu3lib::OuterMultiplicity(irrep1, irrep2, irrep12),
-          rhomaxb = ndsu3lib::OuterMultiplicity(irrep12, irrep3, irrep),
-          rhomaxc = ndsu3lib::OuterMultiplicity(irrep2, irrep3, irrep23),
-          rhomaxd = ndsu3lib::OuterMultiplicity(irrep1, irrep23, irrep);
+      int rhomaxa = ndsu3lib::outer_multiplicity(irrep1, irrep2, irrep12),
+          rhomaxb = ndsu3lib::outer_multiplicity(irrep12, irrep3, irrep),
+          rhomaxc = ndsu3lib::outer_multiplicity(irrep2, irrep3, irrep23),
+          rhomaxd = ndsu3lib::outer_multiplicity(irrep1, irrep23, irrep);
       int dimen = rhomaxa*rhomaxb*rhomaxc*rhomaxd;
       double rac[dimen];
-      int info = ndsu3lib::CalculateUCoef(
-          irrep1, irrep2, irrep, irrep3, irrep12, irrep23, rhomaxa, rhomaxb, rhomaxc, rhomaxd,
-	  rac
-        );
+      int info = ndsu3lib::calculate_u_coef(
+         irrep1, irrep2, irrep, irrep3, irrep12, irrep23,
+         rhomaxa, rhomaxb, rhomaxc, rhomaxd,
+         rac
+         );
       std::cout << std::endl;
       if (info != 0)
       {
-         std::cout << "CalculateUCoef: Lapack subroutine dgesv ran with error: info=" << info << std::endl;
+         std::cout << "calculate_u_coef: Lapack subroutine dgesv ran with error: info=" << info << std::endl;
          return;
       }
       std::cout << "SU(3) recoupling coefficients U[(9,3)(1,1)(6,6)(2,2);(9,3)rhoa,rhob(3,3)rhoc,rhod]" << std::endl;
@@ -142,22 +144,23 @@ void tabulate_z_coef()
    // Tabulate SU(3) recoupling Z coefficients
    // Z[(9,3)(1,1)(6,6)(2,2);(9,3)rhoa,rhob(3,3)rhoc,rhod]
    {
-      ndsu3lib::SU3Irrep irrep2 = {9, 3}, irrep1 = {1, 1}, irrep = {6, 6},
+      ndsu3lib::su3irrep irrep2 = {9, 3}, irrep1 = {1, 1}, irrep = {6, 6},
                          irrep3 = {2, 2}, irrep12 = {9, 3}, irrep13 = {3, 3};
-      int rhomaxa = ndsu3lib::OuterMultiplicity(irrep1, irrep2, irrep12),
-          rhomaxb = ndsu3lib::OuterMultiplicity(irrep12, irrep3, irrep),
-          rhomaxc = ndsu3lib::OuterMultiplicity(irrep1, irrep3, irrep13),
-          rhomaxd = ndsu3lib::OuterMultiplicity(irrep13, irrep2, irrep);
+      int rhomaxa = ndsu3lib::outer_multiplicity(irrep1, irrep2, irrep12),
+          rhomaxb = ndsu3lib::outer_multiplicity(irrep12, irrep3, irrep),
+          rhomaxc = ndsu3lib::outer_multiplicity(irrep1, irrep3, irrep13),
+          rhomaxd = ndsu3lib::outer_multiplicity(irrep13, irrep2, irrep);
       int dimen = rhomaxa*rhomaxb*rhomaxc*rhomaxd;
       double Zcoeff[dimen];
-      int info = ndsu3lib::CalculateZCoef(
-          irrep2, irrep1, irrep, irrep3, irrep12, irrep13, rhomaxa, rhomaxb, rhomaxc, rhomaxd,
-	  Zcoeff
-        );
+      int info = ndsu3lib::calculate_z_coef(
+         irrep2, irrep1, irrep, irrep3, irrep12, irrep13,
+         rhomaxa, rhomaxb, rhomaxc, rhomaxd,
+         Zcoeff
+      );
       std::cout << std::endl;
       if (info != 0)
       {
-         std::cout << "CalculateZCoef: Lapack subroutine dgesv ran with error: info=" << info << std::endl;
+         std::cout << "calculate_z_coef: Lapack subroutine dgesv ran with error: info=" << info << std::endl;
          return;
       }
       std::cout << "SU(3) recoupling coefficients Z[(9,3)(1,1)(6,6)(2,2);(9,3)rhoa,rhob(3,3)rhoc,rhod]" << std::endl;
@@ -186,28 +189,28 @@ void tabulate_nine_lm()
    // |(2,3) (4,2)  (2,4) rho1324|
    // |rho13 rho24 rho1234       |
    {
-      ndsu3lib::SU3Irrep irrep1 = {1, 1}, irrep2 = {0, 0}, irrep12 = {1, 1},
+      ndsu3lib::su3irrep irrep1 = {1, 1}, irrep2 = {0, 0}, irrep12 = {1, 1},
                          irrep3 = {0, 4}, irrep4 = {4, 2}, irrep34 = {2, 4},
                          irrep13 = {2, 3}, irrep24 = {4, 2}, irrep = {2, 4};
-      int rhomax12 = ndsu3lib::OuterMultiplicity(irrep1, irrep2, irrep12),
-          rhomax34 = ndsu3lib::OuterMultiplicity(irrep3, irrep4, irrep34),
-          rhomax1234 = ndsu3lib::OuterMultiplicity(irrep12, irrep34, irrep),
-          rhomax13 = ndsu3lib::OuterMultiplicity(irrep1, irrep3, irrep13),
-          rhomax24 = ndsu3lib::OuterMultiplicity(irrep2, irrep4, irrep24),
-          rhomax1324 = ndsu3lib::OuterMultiplicity(irrep13, irrep24, irrep);
+      int rhomax12 = ndsu3lib::outer_multiplicity(irrep1, irrep2, irrep12),
+          rhomax34 = ndsu3lib::outer_multiplicity(irrep3, irrep4, irrep34),
+          rhomax1234 = ndsu3lib::outer_multiplicity(irrep12, irrep34, irrep),
+          rhomax13 = ndsu3lib::outer_multiplicity(irrep1, irrep3, irrep13),
+          rhomax24 = ndsu3lib::outer_multiplicity(irrep2, irrep4, irrep24),
+          rhomax1324 = ndsu3lib::outer_multiplicity(irrep13, irrep24, irrep);
       int dimen = rhomax12*rhomax34*rhomax1234*rhomax13*rhomax24*rhomax1324;
       double ninelm[dimen];
-      int info = ndsu3lib::Calculate9LambdaMu(
-          irrep1, irrep2, irrep12,
-          irrep3, irrep4, irrep34,
-          irrep13, irrep24, irrep,
-          rhomax12, rhomax34, rhomax1234, rhomax13, rhomax24, rhomax1324,
-          ninelm
-        );
+      int info = ndsu3lib::calculate_9_lambda_mu(
+         irrep1, irrep2, irrep12,
+         irrep3, irrep4, irrep34,
+         irrep13, irrep24, irrep,
+         rhomax12, rhomax34, rhomax1234, rhomax13, rhomax24, rhomax1324,
+         ninelm
+      );
       std::cout << std::endl;
       if (info != 0)
       {
-         std::cout << "Calculate9LambdaMu: Lapack subroutine dgesv ran with error: info=" << info << std::endl;
+         std::cout << "calculate_9_lambda_mu: Lapack subroutine dgesv ran with error: info=" << info << std::endl;
          return;
       }
       std::cout << "                           |(1,1) (0,0)  (1,1)  rho12 |" << std::endl;
@@ -244,12 +247,12 @@ void tabulate_nine_lm()
 
 int main()
 {
-   ndsu3lib::InitializeNdsu3lib(true, false, 50);
+   ndsu3lib::initialize_ndsu3lib(true, false, 50);
    tabulate_coupling_canonical();
    tabulate_coupling_su3so3();
    tabulate_u_coef();
    tabulate_z_coef();
    tabulate_nine_lm();
-   ndsu3lib::FinalizeNdsu3lib(true);
+   ndsu3lib::finalize_ndsu3lib(true);
    return 0;
 }

--- a/ndsu3lib_recoupling.F90
+++ b/ndsu3lib_recoupling.F90
@@ -589,12 +589,14 @@ CONTAINS
 
    END SUBROUTINE calculate_9_lambda_mu
 
-   SUBROUTINE calculate_u_coef_c(irrep1, irrep2, irrep, irrep3, irrep12, irrep23, &
-                                 rhomaxa, rhomaxb, rhomaxc, rhomaxd, racah_ptr, info) BIND(C, NAME="calculate_u_coef")
+   FUNCTION calculate_u_coef_c(irrep1, irrep2, irrep, irrep3, irrep12, irrep23, &
+                               rhomaxa, rhomaxb, rhomaxc, rhomaxd, racah_ptr) &
+      RESULT(info) BIND(C, NAME="calculate_u_coef")
       !------------------------------------------------------------------------------------------------------------------------
       !! Wrapper of subroutine calculate_u_coef for SU(3) recoupling U coefficients
       ! U[(lambda1,mu1)(lambda2,mu2)(lambda,mu)(lambda3,mu3)rhoa,rhob(lambda12,mu12)(lambda23,mu23)rhoc,rhod]
-      !! to be used by C++ wrapper
+      !
+      !! to be used by C/C++ callers
       !
       ! Input arguments: irrep1,irrep2,irrep,irrep3,irrep12,irrep23,rhomaxa,rhomaxb,rhomaxc,rhomaxd
       ! Output arguments: racah_ptr,info
@@ -634,7 +636,7 @@ CONTAINS
          !! Array of U coefficients.
          !! racah_ptr(ind), where ind=rhod-1+rhomaxd*(rhoa-1)+rhomaxd*rhomaxa*(rhob-1)+rhomaxd*rhomaxa*rhomaxb*(rhoc-1),
          !! is U coefficient for given rhoa,rhob,rhoc,rhod.
-      INTEGER(C_INT), INTENT(OUT) :: info
+      INTEGER(C_INT) :: info
          !! Equals 0 iff Lapack subroutine dgesv called by calculate_u_coef ran withou errors.
       REAL(C_DOUBLE), POINTER, DIMENSION(:, :) :: rac
       INTEGER :: rhomaxabc
@@ -642,14 +644,16 @@ CONTAINS
       CALL C_F_POINTER(racah_ptr, rac, [rhomaxd, rhomaxabc])
       CALL calculate_u_coef(irrep1, irrep2, irrep, irrep3, irrep12, irrep23, &
                             rhomaxa, rhomaxb, rhomaxc, rhomaxd, rac, rhomaxd, info)
-   END SUBROUTINE calculate_u_coef_c
+   END FUNCTION calculate_u_coef_c
 
-   SUBROUTINE calculate_z_coef_c(irrep2, irrep1, irrep, irrep3, irrep12, irrep13, &
-                                 rhomaxa, rhomaxb, rhomaxc, rhomaxd, Z_ptr, info) BIND(C, NAME="calculate_z_coef")
+   FUNCTION calculate_z_coef_c(irrep2, irrep1, irrep, irrep3, irrep12, irrep13, &
+                               rhomaxa, rhomaxb, rhomaxc, rhomaxd, Z_ptr) &
+      RESULT(info) BIND(C, NAME="calculate_z_coef")
       !---------------------------------------------------------------------------------------------------------
       !! Wrapper of subroutine calculate_z_coef for SU(3) recoupling Z coefficients
       ! Z[(lambda2,mu2)(lambda1,mu1)(lambda,mu)(lambda3,mu3)rhoa,rhob(lambda12,mu12)(lambda13,mu13)rhoc,rhod]
-      !! to be used by C++ wrapper
+      !
+      !! to be used by C/C++ callers
       !
       ! Input arguments: irrep2,irrep1,irrep,irrep3,irrep12,irrep13,rhomaxa,rhomaxb,rhomaxc,rhomaxd
       ! Output argumrnts: Z_ptr,info
@@ -685,7 +689,7 @@ CONTAINS
          !! Multiplicity of SU(3) coupling 1x3->13
       INTEGER(C_INT), INTENT(IN), VALUE :: rhomaxd
          !! Multiplicity of SU(3) coupling 13x2->irrep
-      INTEGER(C_INT), INTENT(OUT) :: info
+      INTEGER(C_INT) :: info
          !! Equals 0 iff Lapack subroutine dgesv called by calculate_z_coeff ran withou errors.
       TYPE(C_PTR), INTENT(IN), VALUE :: Z_ptr
          !! Array of Z coefficients.
@@ -697,11 +701,11 @@ CONTAINS
       CALL C_F_POINTER(Z_ptr, Zcoeff, [rhomaxd, rhomaxabc])
       CALL calculate_z_coef(irrep2, irrep1, irrep, irrep3, irrep12, irrep13, &
                             rhomaxa, rhomaxb, rhomaxc, rhomaxd, Zcoeff, rhomaxd, info)
-   END SUBROUTINE calculate_z_coef_c
+   END FUNCTION calculate_z_coef_c
 
-   SUBROUTINE calculate_9_lambda_mu_c(irrep1, irrep2, irrep12, irrep3, irrep4, irrep34, irrep13, irrep24, irrep, &
-                                      rhomax12, rhomax34, rhomax1234, rhomax13, rhomax24, rhomax1324, ninelm_ptr, info) &
-      BIND(C, NAME="calculate_9_lambda_mu")
+   FUNCTION calculate_9_lambda_mu_c(irrep1, irrep2, irrep12, irrep3, irrep4, irrep34, irrep13, irrep24, irrep, &
+                                    rhomax12, rhomax34, rhomax1234, rhomax13, rhomax24, rhomax1324, ninelm_ptr) &
+      RESULT(info) BIND(C, NAME="calculate_9_lambda_mu")
       !---------------------------------------------------------------------------------------------------------------------------
       !! Wrapper of subroutine calculate_9_lambda_mu for 9-(lambda,mu) coefficients
       !
@@ -710,7 +714,7 @@ CONTAINS
       ! |(lambda13,mu13) (lambda24,mu24)   (lambda,mu)   rho1324|
       ! |     rho13           rho24          rho1234            |
       !
-      !! to be used by C++ wrapper
+      !! to be used by C/C++ callers
       !
       ! Input arguments: irrep1,irrep2,irrep12,irrep3,irrep4,irrep34,irrep13,irrep24,irrep,
       !                  rhomax12,rhomax34,rhomax1234,rhomax13,rhomax24,rhomax1324
@@ -732,12 +736,12 @@ CONTAINS
       IMPLICIT NONE
       TYPE(su3irrep), INTENT(IN), VALUE :: irrep1, irrep2, irrep12, irrep3, irrep4, irrep34, irrep13, irrep24, irrep
       INTEGER(C_INT), INTENT(IN), VALUE :: rhomax12, rhomax34, rhomax1234, rhomax13, rhomax24, rhomax1324
-      INTEGER(C_INT), INTENT(OUT) :: info
+      INTEGER(C_INT) :: info
       TYPE(C_PTR), INTENT(IN), VALUE :: ninelm_ptr
       REAL(C_DOUBLE), POINTER, DIMENSION(:, :, :, :, :, :) :: ninelm
       CALL C_F_POINTER(ninelm_ptr, ninelm, [rhomax12, rhomax34, rhomax1234, rhomax13, rhomax24, rhomax1324])
       CALL calculate_9_lambda_mu(irrep1, irrep2, irrep12, irrep3, irrep4, irrep34, irrep13, irrep24, irrep, &
                                  rhomax12, rhomax34, rhomax1234, rhomax13, rhomax24, rhomax1324, ninelm, info)
-   END SUBROUTINE calculate_9_lambda_mu_c
+   END FUNCTION calculate_9_lambda_mu_c
 
 END MODULE ndsu3lib_recoupling


### PR DESCRIPTION
I have a particular emphasis here on a) making the interface consistent between C/C++ and Fortran, and b) avoiding wrapper functions. (That's also why there's `ALWAYS_INLINE` defined if possible.)